### PR TITLE
PostとUserのリレーションを追加 | feature/007_createRelatePostUser

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -6,4 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Post extends Model
 {
+    public function user()
+    {
+        return $this->belongsTo('App\User');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -35,4 +35,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany('App\Post');
+    }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -49,7 +49,7 @@ return [
             'database' => env('DB_DATABASE', 'members'),
             'username' => env('DB_USERNAME', 'root'),
             'password' => env('DB_PASSWORD', 'root'),
-            'unix_socket' => env('DB_SOCKET', ''),
+            'unix_socket' => env('DB_SOCKET', '/Applications/MAMP/tmp/mysql/mysql.sock'),
             'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => '',

--- a/database/migrations/2021_08_18_112110_add_column_user_id_to_posts_table.php
+++ b/database/migrations/2021_08_18_112110_add_column_user_id_to_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnUserIdToPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->unsignedBigInteger('user_id')->after('image');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('user_id');
+        });
+    }
+}


### PR DESCRIPTION
**LaravelはModel間でRelationを作成する**

**MVC**
**Model：`/app/`内に作成**
Webシステムのデータを扱う本体部分。Webシステムの中でデータ連携処理などの役割はココ。
データベースから必要な情報の抽出、登録、更新、削除などが主なタスク

**View：`resource/views/`内に作成**
表示させることを担当。Controller、Modelの実行結果をViewが受け取る。Viewが受け取ったデータを元に、htmlを生成して、browserに表示させるhtmlを出力。

**Controller：`/app/Http/Controllers/`内に作成**
ModelとViewをControllするのがController。RequestされたURLやフォームの入力値にしたがって処理を行う。


## リレーションを作る
プロジェクトファイルのapp/Post.php

（laravel6なのでModel dirはない（7も同様））


参考：Model Factory (laravel8から追加されてる)
Model FactoryはEloquentモデルの各フィールドに入る値を定義する役割をもつ
Modelの生産場所といったところ


### リレーションをテーブルに反映する
リレーションを作成したら、その情報をデータベース上のテーブルにも反映
前回作成したpostsテーブルに user_id カラムを作成し、この中に投稿者のuser_idを格納できるようにする
1人のユーザーは複数の投稿データを持つ可能性があるので、usersテーブルにpost_idを作成するのではNG

public function down に、取り消した場合の処理を追加する


### [PDOException]SQLSTATE[HY000] [2002] No such file or directory
`php artisan migrate`を行う時は、必ずMAMP環境を立ち上げて行うこと



【MAMP環境限定】migrateで[PDOException]SQLSTATE[HY000] [2002] No such file or directoryと出た時のメモ
https://bit.ly/3CRl5o5



【Docker環境の場合】調べる
https://bit.ly/3CXbzQ5
→ソケットファイルの有無の確認で問題ない？（作成時に確認する）



ソケットの話
https://bit.ly/3gdaHNF


